### PR TITLE
(doc) Fixed formatting for Markdown

### DIFF
--- a/nanazip.nuspec
+++ b/nanazip.nuspec
@@ -17,42 +17,42 @@
     <projectSourceUrl>https://github.com/M2Team/NanaZip</projectSourceUrl>
     <bugTrackerUrl>https://github.com/M2Team/NanaZip/issues</bugTrackerUrl>
     <description># NanaZip
-      NanaZip is an open source file archiver intended for the modern Windows 
-      experience, forked from the source code of well-known open source file archiver
-      7-Zip.
+NanaZip is an open source file archiver intended for the modern Windows 
+experience, forked from the source code of well-known open source file archiver
+7-Zip.
       
-      **All kinds of contributions will be appreciated. All suggestions, pull 
-      requests and issues are welcome.**
+**All kinds of contributions will be appreciated. All suggestions, pull 
+requests and issues are welcome.**
       
-      ## Features
+## Features
       
-      - Inherit all features from 7-Zip 22.01.
-      - Packaging with MSIX for modern deployment experience.
-      - Support the context menu in Windows 10/11 File Explorer.
-      - Enable NSIS script decompiling support for the NSIS archives. (Merged from 
-        [7-Zip NSIS branch](https://github.com/myfreeer/7z-build-nsis).)
-      - Provide 7-Zip execution alias for helping users to migrate to NanaZip.
-      - Support the Brotli, Fast-LZMA2, Lizard, LZ4, LZ5 and Zstandard codecs. (Merged 
-        from [7-Zip ZS branch](https://github.com/mcmilk/7-Zip-zstd).)
-      - Support the Per-Monitor DPI-Aware for all GUI components.
-      - Support the i18n for GUI edition of Self Extracting Executable.
-      - Integrate the following HASH algorithms to NanaZip from RHash (AICH, BLAKE2b,
-        BTIH, ED2K, EDON-R 224, EDON-R 256, EDON-R 384, EDON-R 512, GOST R 34.11-94, 
-        GOST R 34.11-94 CryptoPro, GOST R 34.11-2012 256, GOST R 34.11-2012 512, 
-        HAS-160, RIPEMD-160, SHA-224, SHA3-224, SHA3-256, SHA3-384, SHA3-512, 
-        Snefru-128, Snefru-256, Tiger, Tiger2, TTH, Whirlpool) and xxHash 
-        (XXH3_64bits, XXH3_128bits).
-      - Enable Control Flow Guard (CFG) to all target binaries for mitigating ROP 
-        attacks.
-      - Mark all x86 and x64 target binaries as compatible with Control-flow 
-        Enforcement Technology (CET) Shadow Stack.
-      - Strict handle checks at runtime to block the use of invalid handles.
-      - Disable dynamic code generation in Release builds prevents generating 
-        malicious code at runtime.
-      - Block loading unexpected libraries from remote sources at runtime.
-      - Enable Package Integrity Check.
-      - Enable EH Continuation Metadata.
-      - Enable Signed Returns.</description>
+- Inherit all features from 7-Zip 22.01.
+- Packaging with MSIX for modern deployment experience.
+- Support the context menu in Windows 10/11 File Explorer.
+- Enable NSIS script decompiling support for the NSIS archives. (Merged from 
+  [7-Zip NSIS branch](https://github.com/myfreeer/7z-build-nsis).)
+- Provide 7-Zip execution alias for helping users to migrate to NanaZip.
+- Support the Brotli, Fast-LZMA2, Lizard, LZ4, LZ5 and Zstandard codecs. (Merged 
+  from [7-Zip ZS branch](https://github.com/mcmilk/7-Zip-zstd).)
+- Support the Per-Monitor DPI-Aware for all GUI components.
+- Support the i18n for GUI edition of Self Extracting Executable.
+- Integrate the following HASH algorithms to NanaZip from RHash (AICH, BLAKE2b,
+  BTIH, ED2K, EDON-R 224, EDON-R 256, EDON-R 384, EDON-R 512, GOST R 34.11-94, 
+  GOST R 34.11-94 CryptoPro, GOST R 34.11-2012 256, GOST R 34.11-2012 512, 
+  HAS-160, RIPEMD-160, SHA-224, SHA3-224, SHA3-256, SHA3-384, SHA3-512, 
+  Snefru-128, Snefru-256, Tiger, Tiger2, TTH, Whirlpool) and xxHash 
+  (XXH3_64bits, XXH3_128bits).
+- Enable Control Flow Guard (CFG) to all target binaries for mitigating ROP 
+  attacks.
+- Mark all x86 and x64 target binaries as compatible with Control-flow 
+  Enforcement Technology (CET) Shadow Stack.
+- Strict handle checks at runtime to block the use of invalid handles.
+- Disable dynamic code generation in Release builds prevents generating 
+  malicious code at runtime.
+- Block loading unexpected libraries from remote sources at runtime.
+- Enable Package Integrity Check.
+- Enable EH Continuation Metadata.
+- Enable Signed Returns.</description>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
Made each line in the description start at the beginning of the line.

This will make the markdown render properly on the Community Repository.